### PR TITLE
Add optional support for user accounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # environment settings
-ENV NPM_CONFIG_LOGLEVEL info
+ENV NPM_CONFIG_LOGLEVEL=info SHOUT_PRIVATE=no
 
 # install packages
 RUN \

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker create \
   -v <path to data>:/config \
   -e PGID=<gid> -e PUID=<uid>  \
   -e TZ=<timezone> \
+  -e SHOUT_PRIVATE=no \
   -p 9000:9000 \
   lsiocommunity/shout-irc
 ```
@@ -51,6 +52,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e TZ` for timezone information, eg Europe/London
+* `-e SHOUT_PRIVATE` set to yes to enable user accounts (See [Set up user accounts](#add-user-accounts)
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it shout /bin/bash`.
 
@@ -68,6 +70,16 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 ## Setting up the application
 
 To log in to the application, browse to https://<hostip>:9000.
+
+### Add user accounts
+
+If you want to add user accounts you must create the container with the `-e SHOUT_PRIVATE` set to yes. See [Usage](#usage). 
+
+```
+docker exec -it shout /usr/bin/with-contenv sh
+cd /app/node_modules/shout; s6-setuidgid abc node index.js add <username> --home /config
+```
+You will be asked to type a password. You can add more users by running the command again with a new username. Then reboot your container using `docker restart shout`
 
 ## Info
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e TZ` for timezone information, eg Europe/London
-* `-e SHOUT_PRIVATE` set to yes to enable user accounts (See [Set up user accounts](#add-user-accounts)
+* `-e SHOUT_PRIVATE` set to yes to enable user accounts (See [Set up user accounts](#add-user-accounts))
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it shout /bin/bash`.
 

--- a/root/etc/services.d/thelounge/run
+++ b/root/etc/services.d/thelounge/run
@@ -2,5 +2,11 @@
 
 cd /app/node_modules/shout || exit
 
-exec \
-	s6-setuidgid abc node index.js --home /config
+if [ $SHOUT_PRIVATE == Y ] || [ $SHOUT_PRIVATE == y ] || [ $SHOUT_PRIVATE == Yes ] || [ $SHOUT_PRIVATE == yes ] || [ $SHOUT_PRIVATE == YES ]
+then
+	exec \
+		s6-setuidgid abc node index.js --private --home /config
+else
+	exec \
+		s6-setuidgid abc node index.js --home /config
+fi


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
Hello, 
This PR adds the ability to enable user account support in the application. Previously this image ran in demo mode, and I wanted the ability to run in "private" mode with user accounts. 

The code is very self explanatory. The only change in the docker file is to add a variabel `SHOUT_PRIVATE` and set it to no by default. This happens on the same line as the other environment setting to not add more layers.

The real change is in the startup script. It is just a simple bash if statement to check if the user set the above mentioned variabel to `yes`. It also accepts `Yes`, `YES`, `y` and `Y` to avoid confusion. If the variabel is set to anything else, including the default `no` the script does exactly the same as before.

There are some changes to the README.md file. I tried to do as few changes as possible and to have clear and concise language in the same formatting as the existing language. 

      -e SHOUT_PRIVATE=no \

Added to the default run command. This is not strictly needed, but it does explain to the user in a very clear manner that they can change it, and how.

> * `-e SHOUT_PRIVATE` set to yes to enable user accounts (See [Set up user accounts](#add-user-accounts))

Added to the list of parameters explained under. The reason why this links to below, is because if its set to yes, adding a user is required to reach the WebUI of the application. 

> ### Add user accounts

Section added to explain how to add user accounts. Since the only way to add user accounts is to run a command in the container. The section is explained in an easy and concise manner. If you got to this point you should as a user be able to very easily follow this section.


##  Thanks, team linuxserver.io

